### PR TITLE
Fixed readme.markdown for you

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -2,7 +2,7 @@
 
 To install the sugar just open terminal and type:
 
-    cd ~/Library/Application Support/Espresso/Sugars
+    cd ~/Library/Application\ Support/Espresso/Sugars
     git clone git://github.com/hawx/Sass.sugar.git
     
 


### PR DESCRIPTION
There was a syntax error with the `cd` command so I just added a backslash. No biggie.
