### PR TITLE
Adjusted multiline comment regex

### DIFF
--- a/Syntaxes/SASS.xml
+++ b/Syntaxes/SASS.xml
@@ -89,7 +89,7 @@
 			        <capture number="0" name="punctuation.begin"/>
 			    </starts-with>
 			    <ends-with>
-			        <expression>^\s*(?!\*)$</expression>
+			        <expression>\s+.*\*/</expression>
 			        <capture number="0" name="punctuation.end"/>
 			    </ends-with>
 			</zone>


### PR DESCRIPTION
Fixed multiline comments where the following block of text would gray-out until a blank line was encountered. See http://cl.ly/123z0j0L1r1F2l0i0J3t
