### PR TITLE
Added .scss files to the list of language extensions.

### DIFF
--- a/Languages.xml
+++ b/Languages.xml
@@ -9,6 +9,7 @@
 		<name>SASS</name>
 		<detectors>
 			<extension>sass</extension>
+			<extension>scss</extension>
 		</detectors>
 		
 		<default-extension>sass</default-extension>


### PR DESCRIPTION
This makes sure that .scss files will be identified as SASS files so that one won't have to set the language of a file via the View -> Language menu each time a .scss file is opened.
