### PR TITLE
Syntax improvements and problems

### DIFF
--- a/Syntaxes/SASS.xml
+++ b/Syntaxes/SASS.xml
@@ -69,7 +69,7 @@
 		<collection name="properties">
 			<include collection="sass-mixin"/>
 			<zone name="property-name">
-				<expression>(?=[a-z-])[a-z-]*(?=: | =)</expression>
+				<expression>(?=[a-z-])[a-z-]*(?=:| =)</expression>
 			</zone>
 			<include collection="values"/>
 		</collection>
@@ -105,11 +105,12 @@
 		<collection name="values">
 			<zone name="property-value">
 				<starts-with>
-					<expression>(=)|(:)(?=\s)</expression>
+					<expression>(=)|(:)(?=)</expression>
 					<capture number="0" name="punctuation.separator.key-value.sass"/>
 				</starts-with>
 				<ends-with>
-					<expression>\n</expression>
+					<expression>;</expression>
+                    <capture number="0" name="punctuation.end"/>
 				</ends-with>
 				<subzones>
 					<include collection="comments"/>

--- a/Syntaxes/SASS.xml
+++ b/Syntaxes/SASS.xml
@@ -110,7 +110,7 @@
 				</starts-with>
 				<ends-with>
 					<expression>;</expression>
-                    <capture number="0" name="punctuation.end"/>
+					<capture number="0" name="punctuation.end"/>
 				</ends-with>
 				<subzones>
 					<include collection="comments"/>

--- a/Syntaxes/SASS.xml
+++ b/Syntaxes/SASS.xml
@@ -89,7 +89,7 @@
 			        <capture number="0" name="punctuation.begin"/>
 			    </starts-with>
 			    <ends-with>
-			        <expression>\s+.*\*/</expression>
+			        <expression>\*/</expression>
 			        <capture number="0" name="punctuation.end"/>
 			    </ends-with>
 			</zone>


### PR DESCRIPTION
This adresses the following things I encountered during the day while going through some old files:
- Multiline comments like `/*example*/` appearing at the end of a property line would cause the comment to span all the way to the next `*/`. This is somewhat similiar to ec04536.
  ![Skjermbilde 2013-03-19 kl 09 28 35](https://f.cloud.github.com/assets/451886/274828/a68d3a18-9073-11e2-85d9-07a6b722d982.png)
- When having multiple properties on one line, only the first property would be correctly highlighted.
  ![Skjermbilde 2013-03-19 kl 10 03 07](https://f.cloud.github.com/assets/451886/274837/e2324d06-9073-11e2-984c-f752d0f6c730.png)
- When having no space between property name and value (`float:left;`), the property wouldn't be highlighted.
  ![Skjermbilde 2013-03-19 kl 10 00 25](https://f.cloud.github.com/assets/451886/274833/b908c630-9073-11e2-9cc7-b39c74561a4b.png)
